### PR TITLE
add port cli args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 data
+local-content-share

--- a/main.go
+++ b/main.go
@@ -50,7 +50,7 @@ type Entry struct {
 	Filename string
 }
 
-var listenAddress = flag.String("listen", "localhost:8080", "host:port in which the server will listen")
+var listenAddress = flag.String("listen", ":8080", "host:port in which the server will listen")
 
 func generateUniqueFilename(baseDir, baseName string) string {
 	// Sanitize: allow only letters, numbers, hyphen, underscore, and space

--- a/main.go
+++ b/main.go
@@ -50,7 +50,7 @@ type Entry struct {
 	Filename string
 }
 
-var port = flag.String("port", "8080", "Port in which the server will listen")
+var listenAddress = flag.String("listen", "localhost:8080", "host:port in which the server will listen")
 
 func generateUniqueFilename(baseDir, baseName string) string {
 	// Sanitize: allow only letters, numbers, hyphen, underscore, and space
@@ -420,5 +420,5 @@ func main() {
 	})
 
 	// Start server
-	log.Fatal(http.ListenAndServe(":" + *port, nil))
+	log.Fatal(http.ListenAndServe(*listenAddress, nil))
 }

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"embed"
+	"flag"
 	"fmt"
 	"html/template"
 	"io"
@@ -49,6 +50,8 @@ type Entry struct {
 	Filename string
 }
 
+var port = flag.String("port", "8080", "Port in which the server will listen")
+
 func generateUniqueFilename(baseDir, baseName string) string {
 	// Sanitize: allow only letters, numbers, hyphen, underscore, and space
 	reg := regexp.MustCompile(`[^a-zA-Z0-9\.\-_\s]`)
@@ -69,6 +72,8 @@ func generateUniqueFilename(baseDir, baseName string) string {
 }
 
 func main() {
+	flag.Parse()
+
 	if err := os.MkdirAll(filepath.Join("data", "files"), 0755); err != nil {
 		log.Fatal(err)
 	}
@@ -415,5 +420,5 @@ func main() {
 	})
 
 	// Start server
-	log.Fatal(http.ListenAndServe(":8080", nil))
+	log.Fatal(http.ListenAndServe(":" + *port, nil))
 }


### PR DESCRIPTION
Since the program can run with both Docker (which by default can map ports) and as a standalone binary, I've added the port as a CLI arg so that the standalone version can be more flexible. This won't change the normal behavior of the program and it is a simple addition. I run many programs on bare-metal and having this flexibility is really good when moving services around.

Thanks for your hard work.